### PR TITLE
Fix height

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -398,9 +398,9 @@ $(function() {
     //トラッシュの近い順にソートします。
     areaModel.sortTrash();
   var accordion_height = window.innerHeight / descriptions.length;
-if(descriptions.length>5){
+  /*if(descriptions.length>5){
     if (accordion_height<100) {accordion_height=100;};
-}
+  }*/
     
     var styleHTML = "";
     var accordionHTML = "";


### PR DESCRIPTION
1画面に全てのゴミ種別が納まるようにした

現状は5種類以上ある場合は100px固定になっていたが、札幌市の6種類でもぎりぎり問題なさそうなので100px固定をなしにした
