### PR TITLE
日付位置の変更

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -76,10 +76,20 @@ a.accordion-toggle-top:hover{
 #gps_area {margin-top: 5px;}
 
 .left-day{
-       font-size: 1.5em;
-       color: white;
-       position: absolute;
-       padding-left: 10px;
+	color: white;
+	position: absolute;
+	padding-left: 10px;
+	padding-right: 10px;
+
+	display: flex;
+	justify-content: space-between;
+	width: 100%;
+}
+.day-text{
+	font-size: 1.5em;
+}
+.date-text{
+	font-size: 1.2em;
 }
 a,a:hover{	
 	color: white;

--- a/css/custom.css
+++ b/css/custom.css
@@ -14,7 +14,7 @@ font-family:".HiraKakuInterface-W1",'Lucida Grande',
 
 .accordion-group{margin-bottom:0;border:0;border-radius:0}
 
-#accordion3 
+#accordion3
 a.accordion-toggle-top{
 	margin: 0;
 	text-align: left;
@@ -63,7 +63,7 @@ a.accordion-toggle-top{
 }
 a.accordion-toggle-top:hover{
 	color: #000000;
-	
+
 }
 .accordion-group-top{background-color:  #ffffff;}
 
@@ -71,7 +71,7 @@ a.accordion-toggle-top:hover{
 
 #accordion2 {display: none;}
 #accordion2 .accordion-inner {text-align: center}
-.date {} 
+.date {}
 
 #gps_area {margin-top: 5px;}
 
@@ -91,7 +91,7 @@ a.accordion-toggle-top:hover{
 .date-text{
 	font-size: 1.2em;
 }
-a,a:hover{	
+a,a:hover{
 	color: white;
 	text-decoration: none;
 }

--- a/js/script.js
+++ b/js/script.js
@@ -131,12 +131,12 @@ var TrashModel = function(_lable, _cell) {
     var day_mix = this.dayCell;
     var result_text = "";
     var day_list = new Array();
-    
+
     // 定期回収の場合
     if (this.regularFlg == 1) {
 
       var today = new Date();
-        
+
       // 12月 +3月　を表現
       for (var i = 0; i < MaxMonth; i++) {
 
@@ -149,7 +149,7 @@ var TrashModel = function(_lable, _cell) {
             continue;
         }
         for (var j in day_mix) {
-          //休止期間だったら、今後一週間ずらす。 
+          //休止期間だったら、今後一週間ずらす。
           var isShift = false;
 
           //week=0が第1週目です。
@@ -417,7 +417,7 @@ $(function() {
   /*if(descriptions.length>5){
     if (accordion_height<100) {accordion_height=100;};
   }*/
-    
+
     var styleHTML = "";
     var accordionHTML = "";
     //アコーディオンの分類から対応の計算を行います。
@@ -473,7 +473,7 @@ $(function() {
           } else {
             leftDayText = leftDay + "日後";
           }
-          
+
           styleHTML += '#accordion-group' + d_no + '{background-color:  ' + description.background + ';} ';
 
           accordionHTML +=
@@ -502,7 +502,7 @@ $(function() {
             "</div>";
       }
     }
-    
+
     $("#accordion-style").html('<!-- ' + styleHTML + ' -->');
 
     var accordion_elm = $("#accordion");
@@ -510,7 +510,7 @@ $(function() {
 
     $('html,body').animate({scrollTop: 0}, 'fast');
 
-    //アコーディオンのラベル部分をクリックしたら  
+    //アコーディオンのラベル部分をクリックしたら
     $(".accordion-body").on("shown.bs.collapse", function() {
       var body = $('body');
       var accordion_offset = $($(this).parent().get(0)).offset().top;
@@ -518,7 +518,7 @@ $(function() {
         scrollTop: accordion_offset
       }, 50);
     });
-    //アコーディオンの非表示部分をクリックしたら  
+    //アコーディオンの非表示部分をクリックしたら
     $(".accordion-body").on("hidden.bs.collapse", function() {
       if ($(".in").length == 0) {
         $("html, body").scrollTop(0);
@@ -562,7 +562,7 @@ $(function() {
 
   //-----------------------------------
   //位置情報をもとに地域を自動的に設定する処理です。
-  //これから下は現在、利用されておりません。 
+  //これから下は現在、利用されておりません。
   //将来的に使うかもしれないので残してあります。
   $("#gps_area").click(function() {
     navigator.geolocation.getCurrentPosition(function(position) {

--- a/js/script.js
+++ b/js/script.js
@@ -102,12 +102,15 @@ var TrashModel = function(_lable, _cell) {
   }
   this.dayLabel = result_text;
 
+  this.getCycleLabel = function() {
+    return this.dayLabel;
+  }
+
   this.getDateLabel = function() {
     if (!this.mostRecent) {
       return "";
     }
-    var result_text = this.mostRecent.getFullYear() + "/" + (1 + this.mostRecent.getMonth()) + "/" + this.mostRecent.getDate();
-    return this.dayLabel + " " + result_text;
+    return (1 + this.mostRecent.getMonth()) + "/" + this.mostRecent.getDate();
   }
 
   var day_enum = ["日", "月", "火", "水", "木", "金", "土"];
@@ -451,6 +454,7 @@ $(function() {
           target_tag += "</ul>";
 
           var dateLabel = trash.getDateLabel();
+          var cycleLabel = trash.getCycleLabel();
           //あと何日かを計算する処理です。
           var leftDay = null;
           if (trash.mostRecent) {
@@ -476,7 +480,10 @@ $(function() {
             '<div class="accordion-group" id="accordion-group' + d_no + '">' +
             '<div class="accordion-heading">' +
             '<a class="accordion-toggle" style="height:' + accordion_height + 'px" data-toggle="collapse" data-parent="#accordion" href="#collapse' + i + '">' +
-            '<div class="left-day">' + leftDayText + '</div>' +
+            '<div class="left-day">' +
+            '<span class="day-text">' + leftDayText + '</span>' +
+            '<span class="date-text">' + dateLabel + '</span>' +
+            '</div>' +
             '<div class="accordion-table" >';
           if (ableSVG && SVGLabel) {
             accordionHTML += '<img src="' + description.styles + '" alt="' + description.label + '"  />';
@@ -484,7 +491,7 @@ $(function() {
             accordionHTML += '<p class="text-center">' + description.label + "</p>";
           }
           accordionHTML += "</div>" +
-            '<h6><p class="text-left date">' + dateLabel + "</p></h6>" +
+            '<h6><p class="text-left date">' + cycleLabel + "</p></h6>" +
             "</a>" +
             "</div>" +
             '<div id="collapse' + i + '" class="accordion-body collapse">' +


### PR DESCRIPTION
5374利用者の方から
「何日後かがすぐに分かるのはとても便利、同時に、それが何日かがもう少し大きく表示されていると嬉しい」
というご意見をいただきました。

確かに日付がもう少し見やすいほうが使い勝手が良いのでは？という気がします。

以下のようにデザインを変更してみました。
良さげであれば本番に入れてみようと思うのですがいかがでしょうか。

今までの
![スクリーンショット 2021-09-26 15 57 38（2）](https://user-images.githubusercontent.com/293996/134797229-4e4f7d94-d971-4a83-813a-6967219b92b2.png)


修正版
![スクリーンショット 2021-09-26 15 56 53（3）](https://user-images.githubusercontent.com/293996/134797272-50cec10d-9c4c-41b0-8372-e11260498f50.png)

